### PR TITLE
Refine end-of-game buttons

### DIFF
--- a/ui/elements/Icon/index.tsx
+++ b/ui/elements/Icon/index.tsx
@@ -20,6 +20,7 @@ console.log(Platform.OS);
 const iconNameMap = {
   back: "arrow-back",
   home: "home-sharp",
+  refresh: "refresh",
   "alert-circle": "alert-circle",
   "checkmark-circle": "checkmark-circle",
   warning: "warning",

--- a/ui/screens/Game/components/LeaveGameButton.tsx
+++ b/ui/screens/Game/components/LeaveGameButton.tsx
@@ -1,5 +1,5 @@
 import { useLeaveGame } from "@/hooks/useLeaveGame";
-import { Button, Icon, Text } from "@/ui/elements";
+import { Button, Icon } from "@/ui/elements";
 import React from "react";
 import { StyleProp, ViewStyle } from "react-native";
 
@@ -11,9 +11,9 @@ export function LeaveGameButton(props: { variant?: "small" | "large" }) {
   const { variant = "small" } = props;
 
   const styles: StyleProp<ViewStyle> =
-    variant === "small"
-      ? { height: "100%", aspectRatio: 1, borderRadius: 100 }
-      : { flexDirection: "row", gap: 8 };
+    variant === "small" ? { height: "100%", aspectRatio: 1, borderRadius: 100 } : undefined;
+
+  const icon = variant === "large" ? "home" : "back";
 
   return (
     <Button
@@ -23,8 +23,7 @@ export function LeaveGameButton(props: { variant?: "small" | "large" }) {
       style={styles}
       fullWidth={variant === "large"}
     >
-      <Icon name="back" size={22} color="white" />
-      {variant === "large" && <Text>Leave Game</Text>}
+      <Icon name={icon} size={22} color="white" />
     </Button>
   );
 }

--- a/ui/screens/Game/components/PlayAgainButton.tsx
+++ b/ui/screens/Game/components/PlayAgainButton.tsx
@@ -1,5 +1,5 @@
 import { usePlayAgain } from '@/hooks/usePlayAgain';
-import { Button, Text } from '@/ui/elements';
+import { Button, Icon } from '@/ui/elements';
 import React from 'react';
 
 export function PlayAgainButton(props: { gameId: string }) {
@@ -11,10 +11,9 @@ export function PlayAgainButton(props: { gameId: string }) {
       color="blue"
       onPress={() => playAgain(gameId)}
       loading={isPlayingAgain}
-      fullWidth
-      style={{ flexDirection: 'row', gap: 8 }}
+      style={{ height: '100%', aspectRatio: 1, borderRadius: 100 }}
     >
-      <Text>Play Again</Text>
+      <Icon name="refresh" size={22} color="white" />
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- shrink LeaveGameButton and PlayAgainButton
- map new `refresh` icon

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688678e5ac9c832aaba6953e311ae060