### PR TITLE
Remove safari controls for ios home screen

### DIFF
--- a/ui/components/WebAppHead.tsx
+++ b/ui/components/WebAppHead.tsx
@@ -13,6 +13,11 @@ export function WebAppHead() {
         rel="apple-touch-icon"
         href={Asset.fromModule(require("@/ui/assets/images/icon.png")).uri}
       />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-title" content="Modi" />
+      <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+      <meta name="mobile-web-app-capable" content="yes" />
+      <meta name="theme-color" content="#35654D" />
       <meta
         property="og:description"
         content="Play with friends, don't end up with the lowest card."


### PR DESCRIPTION
Adds iOS PWA meta tags to enable standalone mode when the app is saved to the Home Screen, removing Safari controls.

This change addresses the user's request for the app to behave more like a native application when launched from the iOS Home Screen, specifically by hiding the Safari browser controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5d0a6e7-a2d0-4b9a-a5fa-e8c7f3298fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5d0a6e7-a2d0-4b9a-a5fa-e8c7f3298fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

