### PR TITLE
Increase player username display length

### DIFF
--- a/ui/screens/Game/components/CardTable/PlayerCircles.tsx
+++ b/ui/screens/Game/components/CardTable/PlayerCircles.tsx
@@ -210,7 +210,7 @@ export function PlayerCircles() {
           opacity: isDragged ? 0.3 : 1,
         }}
       >
-        <Text size={10}>{game.usernames[playerId].slice(0, 2)}</Text>
+        <Text size={10}>{game.usernames[playerId].slice(0, 8)}</Text>
       </Container>
     );
 
@@ -251,7 +251,7 @@ export function PlayerCircles() {
         ]}
       >
         <Text size={10} style={{ color: "white" }}>
-          {game.usernames[draggedPlayerId].slice(0, 2)}
+          {game.usernames[draggedPlayerId].slice(0, 8)}
         </Text>
       </Animated.View>
     );


### PR DESCRIPTION
Increase displayed player username characters from 2 to 8 for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-10cfe56c-ffd0-451a-b992-6bdf0681ac20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10cfe56c-ffd0-451a-b992-6bdf0681ac20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

